### PR TITLE
Add support for .NET 5

### DIFF
--- a/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
+++ b/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>

--- a/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
+++ b/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
+++ b/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/DesktopNotifications.FreeDesktop/FreeDesktopApplicationContext.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopApplicationContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace DesktopNotifications.FreeDesktop
@@ -19,6 +20,12 @@ namespace DesktopNotifications.FreeDesktop
         public static FreeDesktopApplicationContext FromCurrentProcess(string? appIcon = null)
         {
             var mainModule = Process.GetCurrentProcess().MainModule;
+
+            if (mainModule?.FileName == null)
+            {
+                throw new InvalidOperationException("No valid process module found.");
+            }
+
             return new FreeDesktopApplicationContext(
                 Path.GetFileNameWithoutExtension(mainModule.FileName),
                 appIcon

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.0-preview4" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Windows/WindowsApplicationContext.cs
+++ b/DesktopNotifications.Windows/WindowsApplicationContext.cs
@@ -26,7 +26,7 @@ namespace DesktopNotifications.Windows
 
             if (mainModule?.FileName == null)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("No valid process module found.");
             }
 
             var appName = customName ?? Path.GetFileNameWithoutExtension(mainModule.FileName);

--- a/DesktopNotifications.Windows/WindowsApplicationContext.cs
+++ b/DesktopNotifications.Windows/WindowsApplicationContext.cs
@@ -23,6 +23,12 @@ namespace DesktopNotifications.Windows
             string? appUserModelId = null)
         {
             var mainModule = Process.GetCurrentProcess().MainModule;
+
+            if (mainModule?.FileName == null)
+            {
+                throw new InvalidOperationException();
+            }
+
             var appName = customName ?? Path.GetFileNameWithoutExtension(mainModule.FileName);
             var aumid = appUserModelId ?? appName; //TODO: Add seeded bits to avoid collisions?
 

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -14,7 +14,7 @@ namespace DesktopNotifications.Windows
         private readonly WindowsApplicationContext _applicationContext;
         private readonly TaskCompletionSource<string>? _launchActionPromise;
         private readonly Dictionary<ToastNotification, Notification> _notifications;
-        private readonly ToastNotifier _toastNotifier;
+        private readonly ToastNotifierCompat _toastNotifier;
 
         /// <summary>
         /// </summary>

--- a/DesktopNotifications/DesktopNotifications.csproj
+++ b/DesktopNotifications/DesktopNotifications.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>

--- a/Example.Avalonia/Example.Avalonia.csproj
+++ b/Example.Avalonia/Example.Avalonia.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Adding support for .NET 5 via the `net5.0-windows10.0.17763.0` TFM. Turns out that the preview version of `Microsoft.Toolkit.Uwp.Notifications` I was using wasn't fully supported, so I upgraded to version 7.0.2.
I am just wondering if I have to reference `net5.0-windows10.0.17763.0` in _every_ package (Even the Linux/Apple ones)? That's the only way I got this working.

Fixes: https://github.com/pr8x/DesktopNotifications/issues/4

CC: @maxkatz6