### PR TITLE
Target .Netstandard 2.0

### DIFF
--- a/DesktopNotifications.Apple/AppleNotificationManager.cs
+++ b/DesktopNotifications.Apple/AppleNotificationManager.cs
@@ -22,20 +22,20 @@ namespace DesktopNotifications.Apple
 
         public Task Initialize()
         {
-            return default;
+            return Task.CompletedTask;
         }
 
         public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
         {
             ShowNotification();
 
-            return default;
+            return Task.CompletedTask;
         }
 
         public Task ScheduleNotification(Notification notification, DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
         {
-            return default;
+            return Task.CompletedTask;
         }
     }
 }

--- a/DesktopNotifications.Apple/AppleNotificationManager.cs
+++ b/DesktopNotifications.Apple/AppleNotificationManager.cs
@@ -20,19 +20,19 @@ namespace DesktopNotifications.Apple
 
         public string? LaunchActionId { get; }
 
-        public ValueTask Initialize()
+        public Task Initialize()
         {
             return default;
         }
 
-        public ValueTask ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
+        public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
         {
             ShowNotification();
 
             return default;
         }
 
-        public ValueTask ScheduleNotification(Notification notification, DateTimeOffset deliveryTime,
+        public Task ScheduleNotification(Notification notification, DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
         {
             return default;

--- a/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
+++ b/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
@@ -1,19 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
-    <Authors>DesktopNotifications.Apple</Authors>
-    <Product>DesktopNotifications.Apple</Product>
-    <Company>DesktopNotifications.Apple</Company>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
+		<Authors>DesktopNotifications.Apple</Authors>
+		<Product>DesktopNotifications.Apple</Product>
+		<Company>DesktopNotifications.Apple</Company>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
+++ b/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
@@ -2,14 +2,15 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
+++ b/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
@@ -1,21 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications.FreeDesktop\DesktopNotifications.FreeDesktop.csproj" />
-    <ProjectReference Include="..\DesktopNotifications.Windows\DesktopNotifications.Windows.csproj" />
-    <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Avalonia" Version="0.10.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications.FreeDesktop\DesktopNotifications.FreeDesktop.csproj" />
+		<ProjectReference Include="..\DesktopNotifications.Windows\DesktopNotifications.Windows.csproj" />
+		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
+++ b/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
@@ -2,13 +2,15 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -16,7 +18,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.0" />
+		<PackageReference Include="Avalonia" Version="0.10.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
+++ b/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
@@ -1,20 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Tmds.DBus" Version="0.9.1" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Tmds.DBus" Version="0.9.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
+++ b/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
@@ -2,14 +2,15 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/DesktopNotifications.FreeDesktop/FreeDesktopApplicationContext.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopApplicationContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace DesktopNotifications.FreeDesktop
@@ -19,6 +20,12 @@ namespace DesktopNotifications.FreeDesktop
         public static FreeDesktopApplicationContext FromCurrentProcess(string? appIcon = null)
         {
             var mainModule = Process.GetCurrentProcess().MainModule;
+
+            if (mainModule?.FileName == null)
+            {
+                throw new InvalidOperationException("No valid process module found.");
+            }
+
             return new FreeDesktopApplicationContext(
                 Path.GetFileNameWithoutExtension(mainModule.FileName),
                 appIcon

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -41,7 +41,7 @@ namespace DesktopNotifications.FreeDesktop
 
         public string? LaunchActionId { get; }
 
-        public async ValueTask Initialize()
+        public async Task Initialize()
         {
             _connection = Connection.Session;
 
@@ -62,7 +62,7 @@ namespace DesktopNotifications.FreeDesktop
             );
         }
 
-        public async ValueTask ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
+        public async Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
         {
             if (_connection == null || _proxy == null)
             {
@@ -91,7 +91,7 @@ namespace DesktopNotifications.FreeDesktop
             _activeNotifications[id] = notification;
         }
 
-        public async ValueTask ScheduleNotification(
+        public async Task ScheduleNotification(
             Notification notification,
             DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
@@ -135,7 +135,9 @@ namespace DesktopNotifications.FreeDesktop
 
         private void OnNotificationClosed((uint id, uint reason) @event)
         {
-            _activeNotifications.Remove(@event.id, out var notification);
+            var notification = _activeNotifications[@event.id];
+            
+            _activeNotifications.Remove(@event.id);
 
             //TODO: Not sure why but it calls this event twice sometimes
             //In this case the notification has already been removed from the dict.

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Tmds.DBus;

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -2,13 +2,15 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<DefineConstants>WIN64</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<LangVersion>8.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -20,7 +20,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.2" />
+		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications"
+		                  Condition="'$(TargetFramework)' != 'netstandard2.0'"
+		                  Version="7.0.2" />
+		<PackageReference Include="Microsoft.Windows.SDK.Contracts" 
+		                  Condition="'$(TargetFramework)' == 'netstandard2.0'"
+		                  Version="10.0.22000.196" />
 	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -1,17 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.2" />
-  </ItemGroup>
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
+		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.0.2" />
+	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -17,10 +17,14 @@
 		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+		<Compile Remove="NullImpl_WindowsNotificationManager.cs" />
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-		<None Remove="ShellLink.cs" />
-		<None Remove="WindowsNotificationManager.cs" />
-		<None Remove="WindowsApplicationContext.cs" />
+		<Compile Remove="ShellLink.cs" />
+		<Compile Remove="WindowsNotificationManager.cs" />
+		<Compile Remove="WindowsApplicationContext.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -6,7 +6,6 @@
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
 		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
-		<DefineConstants>WIN64</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -18,14 +17,16 @@
 		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+		<None Remove="ShellLink.cs" />
+		<None Remove="WindowsNotificationManager.cs" />
+		<None Remove="WindowsApplicationContext.cs" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications"
-		                  Condition="'$(TargetFramework)' != 'netstandard2.0'"
-		                  Version="7.0.2" />
-		<PackageReference Include="Microsoft.Windows.SDK.Contracts" 
-		                  Condition="'$(TargetFramework)' == 'netstandard2.0'"
-		                  Version="10.0.22000.196" />
+		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Condition="'$(TargetFramework)' != 'netstandard2.0'" Version="7.0.2" />
+		<PackageReference Include="Microsoft.Windows.SDK.Contracts" Condition="'$(TargetFramework)' == 'netstandard2.0'" Version="10.0.22000.196" />
 	</ItemGroup>
 
 </Project>

--- a/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
@@ -1,8 +1,19 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+#pragma warning disable CS0067
+
 namespace DesktopNotifications.Windows
 {
+    internal class WindowsApplicationContext : ApplicationContext
+    {
+        public static WindowsApplicationContext FromCurrentProcess(
+            string? customName = null,
+            string? appUserModelId = null)
+        {
+        }
+    }
+
     internal class WindowsNotificationManager : INotificationManager
     {
         public void Dispose()

--- a/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
@@ -5,20 +5,31 @@ using System.Threading.Tasks;
 
 namespace DesktopNotifications.Windows
 {
-    internal class WindowsApplicationContext : ApplicationContext
+    public class WindowsApplicationContext : ApplicationContext
     {
         public static WindowsApplicationContext FromCurrentProcess(
             string? customName = null,
             string? appUserModelId = null)
         {
+            throw new PlatformNotSupportedException();
+        }
+
+        public WindowsApplicationContext(string name) : base(name)
+        {
+            throw new PlatformNotSupportedException();
         }
     }
 
-    internal class WindowsNotificationManager : INotificationManager
+    public class WindowsNotificationManager : INotificationManager
     {
+        public WindowsNotificationManager(WindowsApplicationContext? context = null)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public void Dispose()
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException();
         }
 
         public string? LaunchActionId { get; }
@@ -29,18 +40,18 @@ namespace DesktopNotifications.Windows
 
         public Task Initialize()
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException();
         }
 
         public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException();
         }
 
         public Task ScheduleNotification(Notification notification, DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DesktopNotifications.Windows
+{
+    internal class WindowsNotificationManager : INotificationManager
+    {
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string? LaunchActionId { get; }
+
+        public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
+
+        public event EventHandler<NotificationDismissedEventArgs>? NotificationDismissed;
+
+        public Task Initialize()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ScheduleNotification(Notification notification, DateTimeOffset deliveryTime,
+            DateTimeOffset? expirationTime = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
-#if WIN64
 using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 using Windows.UI.Notifications;
 
@@ -14,13 +12,10 @@ using System.Diagnostics;
 using Microsoft.Toolkit.Uwp.Notifications;
 #endif
 
-#endif
-
 namespace DesktopNotifications.Windows
 {
     public class WindowsNotificationManager : INotificationManager
     {
-#if WIN64
         private const int LaunchNotificationWaitMs = 5_000;
         private readonly WindowsApplicationContext _applicationContext;
         private readonly TaskCompletionSource<string>? _launchActionPromise;
@@ -32,14 +27,11 @@ namespace DesktopNotifications.Windows
         private readonly ToastNotifierCompat _toastNotifier;
 #endif
 
-#endif
-
         /// <summary>
         /// </summary>
         /// <param name="applicationContext"></param>
         public WindowsNotificationManager(WindowsApplicationContext? applicationContext = null)
         {
-#if WIN64
             _applicationContext = applicationContext ?? WindowsApplicationContext.FromCurrentProcess();
             _launchActionPromise = new TaskCompletionSource<string>();
 
@@ -53,7 +45,6 @@ namespace DesktopNotifications.Windows
                     LaunchActionId = _launchActionPromise.Task.Result;
                 }
             }
-#endif
 
 #if NETSTANDARD
             _toastNotifier = ToastNotificationManager.CreateToastNotifier(_applicationContext.AppUserModelId);
@@ -78,7 +69,6 @@ namespace DesktopNotifications.Windows
 
         public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime)
         {
-#if WIN64
             if (expirationTime < DateTimeOffset.Now)
             {
                 throw new ArgumentException(nameof(expirationTime));
@@ -97,8 +87,6 @@ namespace DesktopNotifications.Windows
             _toastNotifier.Show(toastNotification);
             _notifications[toastNotification] = notification;
 
-#endif
-
             return Task.CompletedTask;
         }
 
@@ -107,7 +95,6 @@ namespace DesktopNotifications.Windows
             DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
         {
-#if WIN64
             if (deliveryTime < DateTimeOffset.Now || deliveryTime > expirationTime)
             {
                 throw new ArgumentException(nameof(deliveryTime));
@@ -120,7 +107,6 @@ namespace DesktopNotifications.Windows
             };
 
             _toastNotifier.AddToSchedule(toastNotification);
-#endif
 
             return Task.CompletedTask;
         }
@@ -129,7 +115,6 @@ namespace DesktopNotifications.Windows
         {
         }
 
-#if WIN64
         private static XmlDocument GenerateXml(Notification notification)
         {
 
@@ -248,6 +233,5 @@ namespace DesktopNotifications.Windows
 
             NotificationActivated?.Invoke(this, new NotificationActivatedEventArgs(notification, actionId));
         }
-#endif
     }
 }

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 using Windows.UI.Notifications;
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 
 #if NETSTANDARD
 using System.IO;
@@ -45,6 +45,7 @@ namespace DesktopNotifications.Windows
                     LaunchActionId = _launchActionPromise.Task.Result;
                 }
             }
+#endif
 
 #if NETSTANDARD
             _toastNotifier = ToastNotificationManager.CreateToastNotifier(_applicationContext.AppUserModelId);
@@ -53,7 +54,6 @@ namespace DesktopNotifications.Windows
 #endif
 
             _notifications = new Dictionary<ToastNotification, Notification>();
-#endif
         }
 
         public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
@@ -117,9 +117,7 @@ namespace DesktopNotifications.Windows
 
         private static XmlDocument GenerateXml(Notification notification)
         {
-
 #if NETSTANDARD
-
             var sw = new StringWriter();
             var xw = XmlWriter.Create(sw, new XmlWriterSettings
             {

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -169,7 +169,7 @@ namespace DesktopNotifications.Windows
                 xw.WriteStartElement("action");
                 xw.WriteAttributeString("content", title);
                 xw.WriteAttributeString("activationType", "foreground");
-                xw.WriteAttributeString("arguments", actionId ?? string.Empty);
+                xw.WriteAttributeString("arguments", actionId);
                 xw.WriteEndElement();
             }
 
@@ -192,7 +192,7 @@ namespace DesktopNotifications.Windows
 
             foreach (var (title, actionId) in notification.Buttons)
             {
-                builder.AddButton(title, ToastActivationType.Foreground, actionId ?? string.Empty);
+                builder.AddButton(title, ToastActivationType.Foreground, actionId);
             }
 
             return builder.GetXml();

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 
 #if WIN64
+using XmlDocument = Windows.Data.Xml.Dom.XmlDocument;
 using Windows.UI.Notifications;
 
 #if NETSTANDARD

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -2,25 +2,31 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+
+#if WIN64
 using Windows.Data.Xml.Dom;
 using Windows.UI.Notifications;
 using Microsoft.Toolkit.Uwp.Notifications;
+#endif
 
 namespace DesktopNotifications.Windows
 {
     public class WindowsNotificationManager : INotificationManager
     {
+#if WIN64
         private const int LaunchNotificationWaitMs = 5_000;
         private readonly WindowsApplicationContext _applicationContext;
         private readonly TaskCompletionSource<string>? _launchActionPromise;
         private readonly Dictionary<ToastNotification, Notification> _notifications;
         private readonly ToastNotifierCompat _toastNotifier;
+#endif
 
         /// <summary>
         /// </summary>
         /// <param name="applicationContext"></param>
         public WindowsNotificationManager(WindowsApplicationContext? applicationContext = null)
         {
+#if WIN64
             _applicationContext = applicationContext ?? WindowsApplicationContext.FromCurrentProcess();
             _launchActionPromise = new TaskCompletionSource<string>();
 
@@ -36,6 +42,7 @@ namespace DesktopNotifications.Windows
 
             _toastNotifier = ToastNotificationManagerCompat.CreateToastNotifier();
             _notifications = new Dictionary<ToastNotification, Notification>();
+#endif
         }
 
         public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
@@ -44,13 +51,14 @@ namespace DesktopNotifications.Windows
 
         public string? LaunchActionId { get; }
 
-        public ValueTask Initialize()
+        public Task Initialize()
         {
             return default;
         }
 
-        public ValueTask ShowNotification(Notification notification, DateTimeOffset? expirationTime)
+        public Task ShowNotification(Notification notification, DateTimeOffset? expirationTime)
         {
+#if WIN64
             if (expirationTime < DateTimeOffset.Now)
             {
                 throw new ArgumentException(nameof(expirationTime));
@@ -69,14 +77,18 @@ namespace DesktopNotifications.Windows
             _toastNotifier.Show(toastNotification);
             _notifications[toastNotification] = notification;
 
+#endif
+
             return default;
         }
 
-        public ValueTask ScheduleNotification(
+        public Task ScheduleNotification(
             Notification notification,
             DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null)
         {
+            
+#if WIN64
             if (deliveryTime < DateTimeOffset.Now || deliveryTime > expirationTime)
             {
                 throw new ArgumentException(nameof(deliveryTime));
@@ -89,6 +101,7 @@ namespace DesktopNotifications.Windows
             };
 
             _toastNotifier.AddToSchedule(toastNotification);
+#endif
 
             return default;
         }
@@ -97,6 +110,7 @@ namespace DesktopNotifications.Windows
         {
         }
 
+#if WIN64
         private static XmlDocument GenerateXml(Notification notification)
         {
             var builder = new ToastContentBuilder();
@@ -156,5 +170,6 @@ namespace DesktopNotifications.Windows
 
             NotificationActivated?.Invoke(this, new NotificationActivatedEventArgs(notification, actionId));
         }
+#endif
     }
 }

--- a/DesktopNotifications/DesktopNotifications.csproj
+++ b/DesktopNotifications/DesktopNotifications.csproj
@@ -2,14 +2,15 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
-
+	
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/DesktopNotifications/DesktopNotifications.csproj
+++ b/DesktopNotifications/DesktopNotifications.csproj
@@ -1,12 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Description>A cross-platform C# library for native desktop "toast" notifications.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pr8x/DesktopNotifications</PackageProjectUrl>
+	</PropertyGroup>
 
 </Project>

--- a/DesktopNotifications/INotificationManager.cs
+++ b/DesktopNotifications/INotificationManager.cs
@@ -32,14 +32,14 @@ namespace DesktopNotifications
         /// Initialized the notification manager.
         /// </summary>
         /// <returns></returns>
-        ValueTask Initialize();
+        Task Initialize();
 
         /// <summary>
         /// Schedules a notification for presentation.
         /// </summary>
         /// <param name="notification">The notification to present.</param>
         /// <param name="expirationTime">The expiration time marking the point when the notification gets removed.</param>
-        ValueTask ShowNotification(Notification notification, DateTimeOffset? expirationTime = null);
+        Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null);
 
         /// <summary>
         /// </summary>
@@ -47,7 +47,7 @@ namespace DesktopNotifications
         /// <param name="deliveryTime"></param>
         /// <param name="expirationTime"></param>
         /// <returns></returns>
-        ValueTask ScheduleNotification(
+        Task ScheduleNotification(
             Notification notification, 
             DateTimeOffset deliveryTime,
             DateTimeOffset? expirationTime = null);

--- a/DesktopNotifications/Notification.cs
+++ b/DesktopNotifications/Notification.cs
@@ -8,13 +8,13 @@ namespace DesktopNotifications
     {
         public Notification()
         {
-            Buttons = new List<(string Title, string ActionId)>();
+            Buttons = new List<(string Title, string? ActionId)>();
         }
 
         public string? Title { get; set; }
 
         public string? Body { get; set; }
 
-        public List<(string Title, string ActionId)> Buttons { get; }
+        public List<(string Title, string? ActionId)> Buttons { get; }
     }
 }

--- a/DesktopNotifications/Notification.cs
+++ b/DesktopNotifications/Notification.cs
@@ -8,13 +8,13 @@ namespace DesktopNotifications
     {
         public Notification()
         {
-            Buttons = new List<(string Title, string? ActionId)>();
+            Buttons = new List<(string Title, string ActionId)>();
         }
 
         public string? Title { get; set; }
 
         public string? Body { get; set; }
 
-        public List<(string Title, string? ActionId)> Buttons { get; }
+        public List<(string Title, string ActionId)> Buttons { get; }
     }
 }

--- a/Example.Avalonia/Example.Avalonia.csproj
+++ b/Example.Avalonia/Example.Avalonia.csproj
@@ -1,15 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
-   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications.Avalonia\DesktopNotifications.Avalonia.csproj" />
-  </ItemGroup>
+
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Avalonia" Version="0.10.0" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications.Avalonia\DesktopNotifications.Avalonia.csproj" />
+	</ItemGroup>
 </Project>

--- a/Example.Avalonia/Example.Avalonia.csproj
+++ b/Example.Avalonia/Example.Avalonia.csproj
@@ -2,20 +2,21 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<LangVersion>8.0</LangVersion>
 		<OutputType>WinExe</OutputType>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="0.10.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+		<PackageReference Include="Avalonia" Version="0.10.11" />
+		<PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="0.10.11" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\DesktopNotifications.Avalonia\DesktopNotifications.Avalonia.csproj" />

--- a/Example.Avalonia/MainWindow.axaml.cs
+++ b/Example.Avalonia/MainWindow.axaml.cs
@@ -65,7 +65,7 @@ namespace Example.Avalonia
                 Body = _bodyTextBox.Text ?? _bodyTextBox.Watermark,
                 Buttons =
                 {
-                    ("This is awesome!", null)
+                    ("This is awesome!", "awesome")
                 }
             });
         }

--- a/Example.Avalonia/MainWindow.axaml.cs
+++ b/Example.Avalonia/MainWindow.axaml.cs
@@ -29,7 +29,8 @@ namespace Example.Avalonia
             _eventsListBox = this.FindControl<ListBox>("EventsListBox");
             _eventsListBox.Items = new ObservableCollection<string>();
 
-            _notificationManager = AvaloniaLocator.Current.GetService<INotificationManager>();
+            _notificationManager = AvaloniaLocator.Current.GetService<INotificationManager>() ??
+                                   throw new InvalidOperationException("Missing notification manager");
             _notificationManager.NotificationActivated += OnNotificationActivated;
             _notificationManager.NotificationDismissed += OnNotificationDismissed;
 

--- a/Example.Avalonia/MainWindow.axaml.cs
+++ b/Example.Avalonia/MainWindow.axaml.cs
@@ -62,7 +62,11 @@ namespace Example.Avalonia
             _notificationManager.ShowNotification(new Notification
             {
                 Title = _titleTextBox.Text ?? _titleTextBox.Watermark,
-                Body = _bodyTextBox.Text ?? _bodyTextBox.Watermark
+                Body = _bodyTextBox.Text ?? _bodyTextBox.Watermark,
+                Buttons =
+                {
+                    ("This is awesome!", null)
+                }
             });
         }
 

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>net5.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopNotifications.Apple\DesktopNotifications.Apple.csproj" />
-    <ProjectReference Include="..\DesktopNotifications.FreeDesktop\DesktopNotifications.FreeDesktop.csproj" />
-    <ProjectReference Include="..\DesktopNotifications.Windows\DesktopNotifications.Windows.csproj" />
-    <ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DesktopNotifications.Apple\DesktopNotifications.Apple.csproj" />
+		<ProjectReference Include="..\DesktopNotifications.FreeDesktop\DesktopNotifications.FreeDesktop.csproj" />
+		<ProjectReference Include="..\DesktopNotifications.Windows\DesktopNotifications.Windows.csproj" />
+		<ProjectReference Include="..\DesktopNotifications\DesktopNotifications.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -2,15 +2,16 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
RIP `ValueTask`  :(

Also the Example.Avalonia project cannot target  .netstandard 2.0 since `AppBuilder` is not available there.

Fixed #7 
Fixed build on non-windows platforms