### PR TITLE
Bugfix: Multiple command execution on button click

### DIFF
--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -158,10 +158,11 @@ namespace DesktopNotifications.FreeDesktop
 
         private void OnNotificationActionInvoked((uint id, string actionKey) @event)
         {
-            if (!_activeNotifications.TryGetValue(@event.id, out var notification)) return;
+            if (!_activeNotifications.TryGetValue(@event.id, out var notification) || notification is null) return;
 
             NotificationActivated?.Invoke(this,
                 new NotificationActivatedEventArgs(notification, @event.actionKey));
+            _activeNotifications.Remove(@event.id);
         }
     }
 }


### PR DESCRIPTION
When you click the button in the notification, its possible that the event gets executed multiple times. Now the notification gets removed from the dictionary after the first execution of "OnNotifyActionInvoked" and will be null if the method runs again for the same command.