### PR TITLE
Update to .NET 6 (LTS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
+++ b/DesktopNotifications.Apple/DesktopNotifications.Apple.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
+++ b/DesktopNotifications.Avalonia/DesktopNotifications.Avalonia.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
+++ b/DesktopNotifications.FreeDesktop/DesktopNotifications.FreeDesktop.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
+++ b/DesktopNotifications.Windows/DesktopNotifications.Windows.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/DesktopNotifications/DesktopNotifications.csproj
+++ b/DesktopNotifications/DesktopNotifications.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 	
 	<PropertyGroup>

--- a/Example.Avalonia/Example.Avalonia.csproj
+++ b/Example.Avalonia/Example.Avalonia.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -2,10 +2,10 @@
 
 	<!--Note: Dotnet currently does not allow to build on non-windows platforms when a windows TFM is specified-->
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0-windows10.0.17763.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
CI was crashing:

> error NETSDK1138: The target framework 'net5.0' is out of support and will not receive security updates in the future.

