### PR TITLE
Image support

### DIFF
--- a/DesktopNotifications.Apple/AppleNotificationManager.cs
+++ b/DesktopNotifications.Apple/AppleNotificationManager.cs
@@ -12,6 +12,8 @@ namespace DesktopNotifications.Apple
         {
         }
 
+        public NotificationManagerCapabilities Capabilities => NotificationManagerCapabilities.None;
+
         public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
         public event EventHandler<NotificationDismissedEventArgs>? NotificationDismissed;
 

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Tmds.DBus;
 
@@ -77,13 +78,32 @@ namespace DesktopNotifications.FreeDesktop
                 0,
                 _appContext.AppIcon ?? string.Empty,
                 notification.Title ?? throw new ArgumentException(),
-                notification.Body ?? throw new ArgumentException(),
+                GenerateNotificationBody(notification),
                 actions.ToArray(),
                 new Dictionary<string, object> { { "urgency", 1 } },
                 duration?.Milliseconds ?? 0
             ).ConfigureAwait(false);
 
             _activeNotifications[id] = notification;
+        }
+
+        private static string GenerateNotificationBody(Notification notification)
+        {
+            if (notification.Body == null)
+            {
+                throw new ArgumentException();
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine(notification.Body);
+
+            if (notification.ImagePath is { } img)
+            {
+                sb.AppendLine($@"<img src=""{img}"" alt=""{notification.ImageAltText}""/>");
+            }
+
+            return sb.ToString();
         }
 
         public async Task HideNotification(Notification notification)

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -55,10 +55,15 @@ namespace DesktopNotifications.FreeDesktop
                 OnNotificationActionInvoked,
                 OnNotificationActionInvokedError
             );
+
             _notificationCloseSubscription = await _proxy.WatchNotificationClosedAsync(
                 OnNotificationClosed,
                 OnNotificationClosedError
             );
+
+            var caps = await _proxy.GetCapabilitiesAsync();
+
+            Console.WriteLine(string.Join(",", caps));
         }
 
         public async Task ShowNotification(Notification notification, DateTimeOffset? expirationTime = null)
@@ -187,7 +192,7 @@ namespace DesktopNotifications.FreeDesktop
                 new NotificationDismissedEventArgs(notification, dismissReason));
         }
 
-        private void OnNotificationActionInvokedError(Exception obj)
+        private static void OnNotificationActionInvokedError(Exception obj)
         {
             throw obj;
         }

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -134,7 +134,7 @@ namespace DesktopNotifications.FreeDesktop
 
             if (notification.ImagePath is { } img)
             {
-                sb.AppendLine($@"<img src=""{img}"" alt=""{notification.ImageAltText}""/>");
+                sb.AppendLine($@"&lt;img src=""{img}"" alt=""{notification.ImageAltText}""/&gt;");
             }
 
             return sb.ToString();

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -87,25 +87,6 @@ namespace DesktopNotifications.FreeDesktop
             _activeNotifications[id] = notification;
         }
 
-        private static string GenerateNotificationBody(Notification notification)
-        {
-            if (notification.Body == null)
-            {
-                throw new ArgumentException();
-            }
-
-            var sb = new StringBuilder();
-
-            sb.AppendLine(notification.Body);
-
-            if (notification.ImagePath is { } img)
-            {
-                sb.AppendLine($@"<img src=""{img}"" alt=""{notification.ImageAltText}""/>");
-            }
-
-            return sb.ToString();
-        }
-
         public async Task HideNotification(Notification notification)
         {
             CheckConnection();
@@ -135,6 +116,25 @@ namespace DesktopNotifications.FreeDesktop
             await ShowNotification(notification, expirationTime);
         }
 
+        private static string GenerateNotificationBody(Notification notification)
+        {
+            if (notification.Body == null)
+            {
+                throw new ArgumentException();
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine(notification.Body);
+
+            if (notification.ImagePath is { } img)
+            {
+                sb.AppendLine($@"<img src=""{img}"" alt=""{notification.ImageAltText}""/>");
+            }
+
+            return sb.ToString();
+        }
+
         private void CheckConnection()
         {
             if (_connection == null || _proxy == null)
@@ -152,7 +152,7 @@ namespace DesktopNotifications.FreeDesktop
             }
         }
 
-        private void OnNotificationClosedError(Exception obj)
+        private static void OnNotificationClosedError(Exception obj)
         {
             throw obj;
         }
@@ -164,7 +164,7 @@ namespace DesktopNotifications.FreeDesktop
                 1 => NotificationDismissReason.Expired,
                 2 => NotificationDismissReason.User,
                 3 => NotificationDismissReason.Application,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => NotificationDismissReason.Unknown
             };
         }
 

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -140,7 +140,7 @@ namespace DesktopNotifications.FreeDesktop
             await ShowNotification(notification, expirationTime);
         }
 
-        private static string GenerateNotificationBody(Notification notification)
+        private string GenerateNotificationBody(Notification notification)
         {
             if (notification.Body == null)
             {
@@ -151,7 +151,8 @@ namespace DesktopNotifications.FreeDesktop
 
             sb.AppendLine(notification.Body);
 
-            if (notification.BodyImagePath is { } img)
+            if (Capabilities.HasFlag(NotificationManagerCapabilities.BodyImages) &&
+                notification.BodyImagePath is { } img)
             {
                 sb.AppendLine($@"<img src=""{img}"" alt=""{notification.BodyImageAltText}""/>");
             }

--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -18,7 +18,7 @@ namespace DesktopNotifications.FreeDesktop
             {
                 { "body", NotificationManagerCapabilities.BodyText },
                 { "body-images", NotificationManagerCapabilities.BodyImages },
-                { "body-images", NotificationManagerCapabilities.BodyMarkup },
+                { "body-markup", NotificationManagerCapabilities.BodyMarkup },
                 { "sound", NotificationManagerCapabilities.Audio },
                 { "icon", NotificationManagerCapabilities.Icon }
             };

--- a/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/NullImpl_WindowsNotificationManager.cs
@@ -34,6 +34,8 @@ namespace DesktopNotifications.Windows
 
         public string? LaunchActionId { get; }
 
+        public NotificationManagerCapabilities Capabilities => NotificationManagerCapabilities.None;
+
         public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
 
         public event EventHandler<NotificationDismissedEventArgs>? NotificationDismissed;

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -161,6 +161,14 @@ namespace DesktopNotifications.Windows
             xw.WriteString(notification.Body ?? string.Empty);
             xw.WriteEndElement();
 
+            if (notification.ImagePath is { } img)
+            {
+                xw.WriteStartElement("image");
+                xw.WriteAttributeString("src", $"file:///{img}");
+                xw.WriteAttributeString("alt", notification.ImageAltText);
+                xw.WriteEndElement();
+            }
+
             xw.WriteEndElement();
 
             xw.WriteEndElement();
@@ -192,6 +200,11 @@ namespace DesktopNotifications.Windows
 
             builder.AddText(notification.Title);
             builder.AddText(notification.Body);
+
+            if (notification.ImagePath is { } img)
+            {
+                builder.AddInlineImage(new Uri($"file:///{img}"), notification.ImageAltText);
+            }
 
             foreach (var (title, actionId) in notification.Buttons)
             {

--- a/DesktopNotifications.Windows/WindowsNotificationManager.cs
+++ b/DesktopNotifications.Windows/WindowsNotificationManager.cs
@@ -58,6 +58,11 @@ namespace DesktopNotifications.Windows
             _scheduledNotification = new Dictionary<ScheduledToastNotification, Notification>();
         }
 
+        public NotificationManagerCapabilities Capabilities => NotificationManagerCapabilities.BodyText |
+                                                               NotificationManagerCapabilities.BodyImages |
+                                                               NotificationManagerCapabilities.Icon |
+                                                               NotificationManagerCapabilities.Audio;
+
         public event EventHandler<NotificationActivatedEventArgs>? NotificationActivated;
 
         public event EventHandler<NotificationDismissedEventArgs>? NotificationDismissed;
@@ -161,11 +166,11 @@ namespace DesktopNotifications.Windows
             xw.WriteString(notification.Body ?? string.Empty);
             xw.WriteEndElement();
 
-            if (notification.ImagePath is { } img)
+            if (notification.BodyImagePath is { } img)
             {
                 xw.WriteStartElement("image");
                 xw.WriteAttributeString("src", $"file:///{img}");
-                xw.WriteAttributeString("alt", notification.ImageAltText);
+                xw.WriteAttributeString("alt", notification.BodyImageAltText);
                 xw.WriteEndElement();
             }
 
@@ -201,9 +206,9 @@ namespace DesktopNotifications.Windows
             builder.AddText(notification.Title);
             builder.AddText(notification.Body);
 
-            if (notification.ImagePath is { } img)
+            if (notification.BodyImagePath is { } img)
             {
-                builder.AddInlineImage(new Uri($"file:///{img}"), notification.ImageAltText);
+                builder.AddInlineImage(new Uri($"file:///{img}"), notification.BodyImageAltText);
             }
 
             foreach (var (title, actionId) in notification.Buttons)

--- a/DesktopNotifications/INotificationManager.cs
+++ b/DesktopNotifications/INotificationManager.cs
@@ -18,6 +18,11 @@ namespace DesktopNotifications
         string? LaunchActionId { get; }
 
         /// <summary>
+        /// Retrieve the capabilities of the notification manager (and its respective platform backend)
+        /// </summary>
+        NotificationManagerCapabilities Capabilities { get; }
+
+        /// <summary>
         /// Raised when a notification was activated. The notion of "activation" varies from platform to platform.
         /// </summary>
         event EventHandler<NotificationActivatedEventArgs> NotificationActivated;

--- a/DesktopNotifications/Notification.cs
+++ b/DesktopNotifications/Notification.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DesktopNotifications
 {
@@ -14,6 +15,10 @@ namespace DesktopNotifications
         public string? Title { get; set; }
 
         public string? Body { get; set; }
+
+        public string? ImagePath { get; set; }
+
+        public string ImageAltText { get; set; } = "Image";
 
         public List<(string Title, string ActionId)> Buttons { get; }
     }

--- a/DesktopNotifications/Notification.cs
+++ b/DesktopNotifications/Notification.cs
@@ -16,9 +16,9 @@ namespace DesktopNotifications
 
         public string? Body { get; set; }
 
-        public string? ImagePath { get; set; }
+        public string? BodyImagePath { get; set; }
 
-        public string ImageAltText { get; set; } = "Image";
+        public string BodyImageAltText { get; set; } = "Image";
 
         public List<(string Title, string ActionId)> Buttons { get; }
     }

--- a/DesktopNotifications/NotificationDismissReason.cs
+++ b/DesktopNotifications/NotificationDismissReason.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// The notification was explicitly removed by application code.
         /// </summary>
-        Application
+        Application,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Unknown
     }
 }

--- a/DesktopNotifications/NotificationManagerCapabilities.cs
+++ b/DesktopNotifications/NotificationManagerCapabilities.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace DesktopNotifications
+{
+    [Flags]
+    public enum NotificationManagerCapabilities
+    {
+        None = 0,
+        BodyText = 1 << 0,
+        BodyImages = 1 << 1,
+        BodyMarkup = 1 << 2,
+        Audio = 1 << 3,
+        Icon = 1 << 4
+    }
+}

--- a/Example.Avalonia/MainWindow.axaml
+++ b/Example.Avalonia/MainWindow.axaml
@@ -17,7 +17,7 @@
         <Button Click="HideLast_OnClick" Content="Hide last notification" />
 
         <TextBlock Foreground="Gray">Events:</TextBlock>
-        <ListBox Name="EventsListBox" Height="200" />
+        <ListBox Name="LogListBox" Height="200" />
     </StackPanel>
 
 </Window>

--- a/Example.Avalonia/MainWindow.axaml
+++ b/Example.Avalonia/MainWindow.axaml
@@ -16,7 +16,7 @@
         <Button Click="Schedule_OnClick" Content="Schedule notification (in 5 Seconds)" />
         <Button Click="HideLast_OnClick" Content="Hide last notification" />
 
-        <TextBlock Foreground="Gray">Events:</TextBlock>
+        <TextBlock Foreground="Gray">Log:</TextBlock>
         <ListBox Name="LogListBox" Height="200" />
     </StackPanel>
 

--- a/Example.Avalonia/MainWindow.axaml
+++ b/Example.Avalonia/MainWindow.axaml
@@ -3,15 +3,16 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
-        Width="400" Height="400"
+        Width="400" Height="500"
         x:Class="Example.Avalonia.MainWindow"
         Title="Example.Avalonia">
 
     <StackPanel Margin="20" Spacing="10">
         <TextBox Name="TitleTextBox" Watermark="Title" UseFloatingWatermark="True" />
         <TextBox Name="BodyTextBox" Watermark="Body" UseFloatingWatermark="True" />
+        <TextBox Name="ImagePathTextBox" Watermark="Image path (optional)" UseFloatingWatermark="True" />
 
-        <Button Click="Show_OnClick" Content="Show Notification" />
+		<Button Click="Show_OnClick" Content="Show Notification" />
         <Button Click="Schedule_OnClick" Content="Schedule notification (in 5 Seconds)" />
         <Button Click="HideLast_OnClick" Content="Hide last notification" />
 

--- a/Example.Avalonia/MainWindow.axaml.cs
+++ b/Example.Avalonia/MainWindow.axaml.cs
@@ -14,6 +14,7 @@ namespace Example.Avalonia
     {
         private readonly TextBox _bodyTextBox;
         private readonly ListBox _eventsListBox;
+        private readonly TextBox _imagePathTextBox;
         private readonly INotificationManager _notificationManager;
         private readonly TextBox _titleTextBox;
 
@@ -28,6 +29,7 @@ namespace Example.Avalonia
 
             _titleTextBox = this.FindControl<TextBox>("TitleTextBox");
             _bodyTextBox = this.FindControl<TextBox>("BodyTextBox");
+            _imagePathTextBox = this.FindControl<TextBox>("ImagePathTextBox");
             _eventsListBox = this.FindControl<ListBox>("EventsListBox");
             _eventsListBox.Items = new ObservableCollection<string>();
 
@@ -72,6 +74,7 @@ namespace Example.Avalonia
                 {
                     Title = _titleTextBox.Text ?? _titleTextBox.Watermark,
                     Body = _bodyTextBox.Text ?? _bodyTextBox.Watermark,
+                    ImagePath = _imagePathTextBox.Text,
                     Buttons =
                     {
                         ("This is awesome!", "awesome")

--- a/Example.Avalonia/MainWindow.axaml.cs
+++ b/Example.Avalonia/MainWindow.axaml.cs
@@ -41,6 +41,12 @@ namespace Example.Avalonia
 
             Log($"Capabilities: {FormatFlagEnum(_notificationManager.Capabilities)}");
 
+            _bodyTextBox.IsEnabled =
+                _notificationManager.Capabilities.HasFlag(NotificationManagerCapabilities.BodyText);
+
+            _imagePathTextBox.IsEnabled =
+                _notificationManager.Capabilities.HasFlag(NotificationManagerCapabilities.BodyImages);
+
             if (_notificationManager.LaunchActionId != null)
             {
                 Log($"Launch action: {_notificationManager.LaunchActionId}");
@@ -51,7 +57,7 @@ namespace Example.Avalonia
         {
             var enumValues = (TEnum[])Enum.GetValues(typeof(TEnum));
 
-            return string.Join(",",
+            return string.Join(", ",
                 enumValues
                     .Where(x => Convert.ToInt32(x) != 0 && e.HasFlag(x))
                     .Select(x => x.ToString()));

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ A cross-platform C# library for native desktop "toast" notifications.
 | Show notifications  | ✓       | ✓                   | ✕   |
 | Hide notifications  | ✓       | ✓                   | ✕   |
 | Schedule notifications | ✓       | ✓*                   | ✕   |
-| Launch actions**         | ✓***       | ✕                   |  ✕   |
+| Launch actions         | ✓**       | ✕                   |  ✕   |
 | Replacing notifications                | ✕       | ✕                   |  ✕   |
 | Buttons                  | ✓       | ✓                   |  ✕   |
-| Advanced content (Audio, Images, etc)                  | ✕       | ✕                   |  ✕   |
+| Audio                  | ✕       | ✕                   |  ✕   |
+| Images                  | ✓       | ✓***                   |  ✕   |
 
 <sub> * Scheduled notifications will only be delivered while the application is running. </sub>  
-<sub> ** Some platforms support launching your application when the user clicked a notification. The associated action identifier is passed as a command-line argument. </sub>  
-<sub> *** This is currently not supported when targeting .netstandard
+<sub> ** This is currently not supported when targeting .netstandard </sub>
+<sub> *** If supported by the notification server </sub>
 
 # Application Context
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A cross-platform C# library for native desktop "toast" notifications.
 | Images                  | ✓       | ✓***                   |  ✕   |
 
 <sub> * Scheduled notifications will only be delivered while the application is running. </sub>  
-<sub> ** This is currently not supported when targeting .netstandard </sub>
+<sub> ** This is currently not supported when targeting .netstandard </sub>  
 <sub> *** If supported by the notification server </sub>
 
 # Application Context


### PR DESCRIPTION
Support embedding images in the notification body.

![image](https://github.com/pr8x/DesktopNotifications/assets/4670166/ccbc5b71-007a-4c61-b158-cc9e002f4d17)

Unfortunately Notify OSD (Ubuntu's notification system) does **not** support inline body images. Therefore I added a new `NotificationManagerCapabilities` enum that allows to query which features are supported by the notification manager and its respective platform backend.

