### PR TITLE
FreeDesktop: fix duration and body height.

### DIFF
--- a/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
+++ b/DesktopNotifications.FreeDesktop/FreeDesktopNotificationManager.cs
@@ -105,7 +105,7 @@ namespace DesktopNotifications.FreeDesktop
                 GenerateNotificationBody(notification),
                 actions.ToArray(),
                 new Dictionary<string, object> { { "urgency", 1 } },
-                duration?.Milliseconds ?? 0
+                (int?) duration?.TotalMilliseconds ?? 0
             ).ConfigureAwait(false);
 
             _activeNotifications[id] = notification;
@@ -149,12 +149,12 @@ namespace DesktopNotifications.FreeDesktop
 
             var sb = new StringBuilder();
 
-            sb.AppendLine(notification.Body);
+            sb.Append(notification.Body);
 
             if (Capabilities.HasFlag(NotificationManagerCapabilities.BodyImages) &&
                 notification.BodyImagePath is { } img)
             {
-                sb.AppendLine($@"<img src=""{img}"" alt=""{notification.BodyImageAltText}""/>");
+                sb.Append($@"\n<img src=""{img}"" alt=""{notification.BodyImageAltText}""/>");
             }
 
             return sb.ToString();


### PR DESCRIPTION
- Use [`TimeSpan.TotalMilliseconds`](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.totalmilliseconds?view=net-7.0) instead of [`TimeSpan.Milliseconds`](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.milliseconds?view=net-7.0#system-timespan-milliseconds) as duration.
- Don't append a newline to the body unless an image is specified in order to remove the trailing empty line from the notification popup.